### PR TITLE
[FEATURE] use gVCF with compression

### DIFF
--- a/bin/gatk_vc.sh
+++ b/bin/gatk_vc.sh
@@ -67,7 +67,8 @@ OUTPUT_MODE_HC=""
 if [[ "$reference_calls" == "True" ]]
 then
 	OUTPUT_MODE_UG="--output_mode emit_all_sites"
-	OUTPUT_MODE_HC="-ERC BP_RESOLUTION"
+        # default bands are 5,20,60, we save some space by going 20,60
+        OUTPUT_MODE_HC="-ERC GVCF -variant_index_type LINEAR -variant_index_parameter 128000 -GQB 20 -GQB 60"
 	NO_VARIATION="-selecttype no_variation"
 fi
 


### PR DESCRIPTION
compress gVCF using the "-ERC GVCF" option which leads to signficant disk space
reduction of the produced gVCF file. Furthermore, we only use 3 different bands
instead of 4 (default). See also:

http://gatkforums.broadinstitute.org/gatk/discussion/4017/what-is-a-gvcf-and-how-is-it-different-from-a-regular-vcf
